### PR TITLE
Update Regex and parsing methods in Angle.cs

### DIFF
--- a/src/Asv.Common.Test/AngleTest.cs
+++ b/src/Asv.Common.Test/AngleTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Asv.Common.Test;
@@ -37,6 +38,8 @@ public class AngleTest
         Assert.True(Angle.TryParse(@"0~ 0' 0""",out value));
         Assert.Equal(0,value);
         Assert.True(Angle.TryParse(@"0* 0' 0""",out value));
+        Assert.Equal(0,value);
+        Assert.True(Angle.TryParse(@"0 0' 0""",out value));
         Assert.Equal(0,value);
     }
     
@@ -88,8 +91,8 @@ public class AngleTest
         var value = 0.0;
         Assert.True(Angle.TryParse("0 0 0",out value));
         Assert.Equal(0,value);
-        Assert.False(Angle.TryParse("0 0",out value));
-        Assert.Equal(0,value);
+        Assert.True(Angle.TryParse("2 40",out value));
+        Assert.Equal(2 + 40.0 / 60.0,value);
         Assert.True(Angle.TryParse("0",out value));
         Assert.Equal(0,value);
     }
@@ -112,6 +115,38 @@ public class AngleTest
         Assert.Equal(-289,value);
         Assert.True(Angle.TryParse("-054 0 0",out value));
         Assert.Equal(-54,value);
+        
+        Assert.True(Angle.TryParse("+045 0",out value));
+        Assert.Equal(45,value);
+        Assert.True(Angle.TryParse("-090 0",out value));
+        Assert.Equal(-90,value);
+        Assert.True(Angle.TryParse("060 0",out value));
+        Assert.Equal(60,value);
+        Assert.True(Angle.TryParse("180 0",out value));
+        Assert.Equal(180,value);
+        Assert.True(Angle.TryParse("089 0",out value));
+        Assert.Equal(89,value);
+        Assert.True(Angle.TryParse("-289 0",out value));
+        Assert.Equal(-289,value);
+        Assert.True(Angle.TryParse("-054 0",out value));
+        Assert.Equal(-54,value);
+        
+        Assert.True(Angle.TryParse("+045",out value));
+        Assert.Equal(45,value);
+        Assert.True(Angle.TryParse("-090",out value));
+        Assert.Equal(-90,value);
+        Assert.True(Angle.TryParse("060",out value));
+        Assert.Equal(60,value);
+        Assert.True(Angle.TryParse("180",out value));
+        Assert.Equal(180,value);
+        Assert.True(Angle.TryParse("089",out value));
+        Assert.Equal(89,value);
+        Assert.True(Angle.TryParse("-289",out value));
+        Assert.Equal(-289,value);
+        Assert.True(Angle.TryParse("-054",out value));
+        Assert.Equal(-54,value);
+        Assert.True(Angle.TryParse("001054000",out value));
+        Assert.Equal(1054000,value);
     }
     
     [Fact]
@@ -128,6 +163,17 @@ public class AngleTest
         Assert.Equal(9.0/60.0,value);
         Assert.True(Angle.TryParse("00 59 00",out value));
         Assert.Equal(59.0/60.0,value);
+        
+        Assert.True(Angle.TryParse("00 30",out value));
+        Assert.Equal(30.0/60.0,value);
+        Assert.True(Angle.TryParse("-00 1",out value));
+        Assert.Equal(-1.0/60.0,value);
+        Assert.True(Angle.TryParse("00 09",out value));
+        Assert.Equal(9.0/60.0,value);
+        Assert.True(Angle.TryParse("-00 9",out value));
+        Assert.Equal(-9.0/60.0,value);
+        Assert.True(Angle.TryParse("00 59",out value));
+        Assert.Equal(59.0/60.0,value);
     }
     
     [Fact]
@@ -136,23 +182,23 @@ public class AngleTest
         var value = 0.0;
         Assert.True(Angle.TryParse("00 00 01",out value));
         Assert.Equal(1.0/3600.0,value);
-        Assert.True(Angle.TryParse("00 00 1",out value));
-        Assert.Equal(1.0/3600.0,value);
+        Assert.True(Angle.TryParse("-00 00 1",out value));
+        Assert.Equal(-1.0/3600.0,value);
         Assert.True(Angle.TryParse("00 00 09",out value));
         Assert.Equal(9.0/3600.0,value);
-        Assert.True(Angle.TryParse("00 00 9",out value));
-        Assert.Equal(9.0/3600.0,value);
+        Assert.True(Angle.TryParse("-00 00 9",out value));
+        Assert.Equal(-9.0/3600.0,value);
         Assert.True(Angle.TryParse("00 00 59",out value));
         Assert.Equal(59.0/3600.0,value);
-        Assert.True(Angle.TryParse("00 00 01.001",out value));
-        Assert.Equal(1.0/3600.0,value);
+        Assert.True(Angle.TryParse("-00 00 01.001",out value));
+        Assert.Equal(-1.0/3600.0,value);
         Assert.True(Angle.TryParse("00 00 1.001",out value));
         Assert.Equal(1.0/3600.0,value);
-        Assert.True(Angle.TryParse("00 00 09.001",out value));
-        Assert.Equal(9.0/3600.0,value);
+        Assert.True(Angle.TryParse("-00 00 09.001",out value));
+        Assert.Equal(-9.0/3600.0,value);
         Assert.True(Angle.TryParse("00 00 9.001",out value));
         Assert.Equal(9.0/3600.0,value);
-        Assert.True(Angle.TryParse("00 00 59.001",out value));
-        Assert.Equal(59.0/3600.0,value);
+        Assert.True(Angle.TryParse("-00 00 59.001",out value));
+        Assert.Equal(-59.0/3600.0,value);
     }
 }


### PR DESCRIPTION
Updated the regular expression and parsing methods in Angle.cs to correctly interpret and handle angle strings containing degrees, minutes and seconds, and added corresponding tests. Now, the parser supports both positive and negative angles, can handle extra leading zeros, and correctly calculates the angle's value when given an angle string without minutes and seconds. Furthermore, the appropriate error messages are given when input angles are invalid.

Asana: https://app.asana.com/0/1203851531040615/1205102232827105/f