### PR TITLE
fix: configuration overwrite in JSON files

### DIFF
--- a/src/Asv.Cfg/Json/JsonConfiguration.cs
+++ b/src/Asv.Cfg/Json/JsonConfiguration.cs
@@ -53,9 +53,12 @@ namespace Asv.Cfg.Json
         public void Set<TPocoType>(string key, TPocoType value)
         {
             ConfigurationHelper.ValidateKey(key);
-            _lock.Execute(key,()=>
-                File.WriteAllText(Path.Combine(_folderPath, key + ".json"),
-                    JsonConvert.SerializeObject(value, Formatting.Indented)));
+            _lock.Execute(key, () =>
+            {
+                var filepath = Path.Combine(_folderPath, key + ".json");
+                File.Delete(filepath);
+                File.WriteAllText(filepath, JsonConvert.SerializeObject(value, Formatting.Indented));
+            });
         }
 
         public void Remove(string key)

--- a/src/Asv.Cfg/Json/ZipJsonConfiguration.cs
+++ b/src/Asv.Cfg/Json/ZipJsonConfiguration.cs
@@ -82,7 +82,8 @@ namespace Asv.Cfg.Json
             var fileName = key+FileExt;
             lock (_sync)
             {
-                var entry = _archive.GetEntry(fileName) ?? _archive.CreateEntry(fileName);
+                _archive.GetEntry(fileName)?.Delete();
+                var entry = _archive.CreateEntry(fileName);
                 using var wrt = new JsonTextWriter(new StreamWriter(entry.Open()));
                 var serializer = new JsonSerializer
                 {


### PR DESCRIPTION
This commit resolves an issue where updating a JSON configuration was appending new data instead of overwriting old ones. To ensure old data is cleared before updating, explicit deletion of existing JSON objects was added in Set methods of both ZipJsonConfiguration.cs and JsonConfiguration.cs classes. Now, new values completely overwrite old ones.

Asana: https://app.asana.com/0/1203851531040615/1205513102246653/f