### PR TITLE
fix: update format for angle and geo point representations

### DIFF
--- a/src/Asv.Common.Test/AngleMsTest.cs
+++ b/src/Asv.Common.Test/AngleMsTest.cs
@@ -67,29 +67,29 @@ public class AngleMsTest
         var value = 0.0;
         Assert.True(AngleMs.TryParse("30 00",out value));
         Assert.Equal(30.0/60.0,value);
-        Assert.Equal("30′0,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("30′00,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("1 00",out value));
         Assert.Equal(1.0/60.0,value);
-        Assert.Equal("1′0,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("01′00,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("09 00",out value));
         Assert.Equal(9.0/60.0,value);
-        Assert.Equal("9′0,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("09′00,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("9 00",out value));
         Assert.Equal(9.0/60.0,value);
-        Assert.Equal("9′0,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("09′00,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("59 00",out value));
         Assert.Equal(59.0/60.0,value);
-        Assert.Equal("59′0,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("59′00,00˝", AngleMs.PrintMs(value));
         
         Assert.True(AngleMs.TryParse("120 30",out value));
         Assert.Equal(120.0/60.0 + 30.0/3600.0,value);
         Assert.Equal("120′30,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("-92 1",out value));
         Assert.Equal(-92.0/60.0 - 1.0/3600.0,value);
-        Assert.Equal("92′1,00˝", AngleMs.PrintMs(value));
+        Assert.Equal("92′01,00˝", AngleMs.PrintMs(value));
         Assert.True(AngleMs.TryParse("10000 09.14",out value));
         Assert.Equal( 10000.0/60.0 + 9.14/3600.0,value);
-        Assert.Equal("10000′9,14˝", AngleMs.PrintMs(value));
+        Assert.Equal("10000′09,14˝", AngleMs.PrintMs(value));
     }
 
     [Fact]

--- a/src/Asv.Common.Test/AngleTest.cs
+++ b/src/Asv.Common.Test/AngleTest.cs
@@ -104,7 +104,7 @@ public class AngleTest
         Assert.Equal(0,value);
         Assert.True(Angle.TryParse("2 40",out value));
         Assert.Equal(2 + 40.0 / 60.0,value);
-        Assert.Equal("2°40′0,00˝", Angle.PrintDms(value));
+        Assert.Equal("02°40′00,00˝", Angle.PrintDms(value));
         Assert.True(Angle.TryParse("0",out value));
         Assert.Equal(0,value);
     }

--- a/src/Asv.Common.Test/GeoPointLatitudeTest.cs
+++ b/src/Asv.Common.Test/GeoPointLatitudeTest.cs
@@ -180,19 +180,19 @@ public class GeoPointLatitudeTest
         var value = 0.0;
         Assert.True(GeoPointLatitude.TryParse("2 40",out value));
         Assert.Equal(2 + 40d/60d,value);
-        Assert.Equal("2°40′0.00˝ N", GeoPointLatitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("02°40′00.00˝ N", GeoPointLatitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLatitude.TryParse("15 59 45",out value));
         Assert.Equal(15 + 59d/60d + 45d/3600d,value);
         Assert.Equal("15°59′45.00˝ N", GeoPointLatitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLatitude.TryParse("0 1 0 S",out value));
         Assert.Equal(-1d/60d,value);
-        Assert.Equal("0°1′0.00˝ S", GeoPointLatitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("00°01′00.00˝ S", GeoPointLatitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLatitude.TryParse("15 59 45,15 S",out value));
         Assert.Equal(-15 + -59d/60d + -45.15d/3600d,value);
         Assert.Equal("15°59′45.15˝ S", GeoPointLatitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLatitude.TryParse("0 1 0.94 S",out value));
         Assert.Equal(-(1d/60d + 0.94/3600d),value);
-        Assert.Equal("0°1′0.94˝ S", GeoPointLatitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("00°01′00.94˝ S", GeoPointLatitude.PrintDms(value).Replace(",", "."));
     }
     
     [Fact]

--- a/src/Asv.Common.Test/GeoPointLongitudeTest.cs
+++ b/src/Asv.Common.Test/GeoPointLongitudeTest.cs
@@ -219,26 +219,26 @@ public class GeoPointLongitudeTest
         var value = 0.0;
         Assert.True(GeoPointLongitude.TryParse("2 40",out value));
         Assert.Equal(2 + 40d/60d,value);
-        Assert.Equal("2°40′0.00˝ E", GeoPointLongitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("002°40′00.00˝ E", GeoPointLongitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLongitude.TryParse("15 59 45",out value));
         Assert.Equal(15 + 59d/60d + 45d/3600d,value);
-        Assert.Equal("15°59′45.00˝ E", GeoPointLongitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("015°59′45.00˝ E", GeoPointLongitude.PrintDms(value).Replace(",", "."));
         Assert.True(GeoPointLongitude.TryParse("0 1 0 W",out value));
         Assert.Equal(-1d/60d,value);
-        Assert.Equal("0°1′0.00˝ W", GeoPointLongitude.PrintDms(value).Replace(",", "."));
+        Assert.Equal("000°01′00.00˝ W", GeoPointLongitude.PrintDms(value).Replace(",", "."));
     }
 
     [Fact]
     public void CheckValidLongitudeDegValues()
     {
         var value = 0.0;
-        Assert.True(GeoPointLongitude.TryParse("001 0 0 E",out value));
+        Assert.True(GeoPointLongitude.TryParse("001 00 00.00 E",out value));
         Assert.Equal(1,value);
-        Assert.True(GeoPointLongitude.TryParse("01 0 0 E",out value));
+        Assert.True(GeoPointLongitude.TryParse("01 00 00.00 E",out value));
         Assert.Equal(1,value);
-        Assert.True(GeoPointLongitude.TryParse("1 0 0 E",out value));
+        Assert.True(GeoPointLongitude.TryParse("1 00 00.00 E",out value));
         Assert.Equal(1,value);
-        Assert.True(GeoPointLongitude.TryParse("10 0 0 E",out value));
+        Assert.True(GeoPointLongitude.TryParse("10 00 00.00 E",out value));
         Assert.Equal(10,value);
         Assert.True(GeoPointLongitude.TryParse("99 0 0 E",out value));
         Assert.Equal(99,value);

--- a/src/Asv.Common/Other/Angle.cs
+++ b/src/Asv.Common/Other/Angle.cs
@@ -114,7 +114,7 @@ namespace Asv.Common
                 minutes++;
                 seconds -= 60;
             }
-            return $"{Math.Sign(decimalDegrees) * degrees}°{minutes}′{seconds:F2}˝";  
+            return $"{Math.Sign(decimalDegrees) * degrees:00}°{minutes:00}′{seconds:00.00}˝";  
         }
     }
 }

--- a/src/Asv.Common/Other/AngleMs.cs
+++ b/src/Asv.Common/Other/AngleMs.cs
@@ -20,7 +20,7 @@ namespace Asv.Common
         
         public static string? GetErrorMessage(string value)
         {
-            return IsValid(value) == false ? RS.Angle_ErrorMessage : null;
+            return IsValid(value) == false ? RS.AngleMs_ErrorMessage : null;
         }
         
         public static bool TryParse(string value, out double angle)

--- a/src/Asv.Common/Other/AngleMs.cs
+++ b/src/Asv.Common/Other/AngleMs.cs
@@ -109,7 +109,7 @@ namespace Asv.Common
                 minutes++;
                 seconds -= 60;
             }
-            return $"{Math.Sign(decimalDegrees) * minutes}′{seconds:F2}˝";  
+            return $"{Math.Sign(decimalDegrees) * minutes:00}′{seconds:00.00}˝";  
         }
     }
 }

--- a/src/Asv.Common/Other/GeoPoint/GeoPointLatitude.cs
+++ b/src/Asv.Common/Other/GeoPoint/GeoPointLatitude.cs
@@ -107,7 +107,7 @@ namespace Asv.Common
                 minutes++;
                 seconds -= 60;
             }
-            return $"{degrees}°{minutes}′{seconds:F2}˝ {(latitude < 0 ? "S" : "N")}";  
+            return $"{degrees:00}°{minutes:00}′{seconds:00.00}˝ {(latitude < 0 ? "S" : "N")}";  
         }
         
     }

--- a/src/Asv.Common/Other/GeoPoint/GeoPointLongitude.cs
+++ b/src/Asv.Common/Other/GeoPoint/GeoPointLongitude.cs
@@ -110,7 +110,7 @@ namespace Asv.Common
                 minutes++;
                 seconds -= 60;
             }
-            return $"{degrees}°{minutes}′{seconds:F2}˝ {(longitude < 0 ? "W" : "E")}";  
+            return $"{degrees:000}°{minutes:00}′{seconds:00.00}˝ {(longitude < 0 ? "W" : "E")}";  
         }
     }
 }

--- a/src/Asv.Common/RS.Designer.cs
+++ b/src/Asv.Common/RS.Designer.cs
@@ -69,6 +69,15 @@ namespace Asv.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Angle must be a real number or MS format value (e.g. 34′56.78).
+        /// </summary>
+        internal static string AngleMs_ErrorMessage {
+            get {
+                return ResourceManager.GetString("AngleMs_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Latitude must be a real number from -90.0 to 90.0 or DMS format value (e.g. 12°34′56.78 N).
         /// </summary>
         internal static string GeoPointLatitude_ErrorMessage {

--- a/src/Asv.Common/RS.resx
+++ b/src/Asv.Common/RS.resx
@@ -27,4 +27,7 @@
     <data name="Angle_ErrorMessage" xml:space="preserve">
         <value>Angle must be a real number or DMS format value (e.g. 12°34′56.78)</value>
     </data>
+    <data name="AngleMs_ErrorMessage" xml:space="preserve">
+        <value>Angle must be a real number or MS format value (e.g. 34′56.78)</value>
+    </data>
 </root>

--- a/src/Asv.Common/RS.ru.resx
+++ b/src/Asv.Common/RS.ru.resx
@@ -20,4 +20,7 @@
     <data name="Angle_ErrorMessage" xml:space="preserve">
         <value>Угол должен быть дробным числом или значением в формате ГМС (например, 12°34′56.78).</value>
     </data>
+    <data name="AngleMs_ErrorMessage" xml:space="preserve">
+        <value>Угол должен быть дробным числом или значением в формате МС (например, 34′56.78).</value>
+    </data>
 </root>


### PR DESCRIPTION
This commit ensures consistent formatting of angle and geopoint data in all print methods. Padded zeroes were added to maintain consistent minute and second widths for better readability and clarity when viewing the data. Tests have been updated to match this new format.

Asana: https://app.asana.com/0/1203851531040615/1205715713006945/f