### PR TITLE
fix: Improve longitude parsing in GeoPoint

### DIFF
--- a/src/Asv.Common.Test/GeoPointLongitudeTest.cs
+++ b/src/Asv.Common.Test/GeoPointLongitudeTest.cs
@@ -160,14 +160,19 @@ public class GeoPointLongitudeTest
     public void Check_double_values()
     {
         var value = 0.0;
-        Assert.True(GeoPointLongitude.TryParse("65.536",out value));
-        Assert.Equal(65.536,value);
+        
+        // for (double i = -179.999999; i < 179.999999; i += 0.000001)
+        // {
+        //     Assert.True(GeoPointLongitude.TryParse(i.ToString("F6"),out value));
+        // }
+        
+        Assert.True(GeoPointLongitude.TryParse("85.536123",out value));
+        Assert.Equal(85.536123,value);
         
         Assert.True(GeoPointLongitude.TryParse("-65,536",out value));
         Assert.Equal(-65.536,value);
         
         Assert.False(GeoPointLongitude.TryParse("180,536",out value));
-        
     }
 
     

--- a/src/Asv.Common/Other/GeoPoint/GeoPointLongitude.cs
+++ b/src/Asv.Common/Other/GeoPoint/GeoPointLongitude.cs
@@ -10,7 +10,8 @@ namespace Asv.Common
         private const double Min = -180;
         private const double Max = 180;
         private const string MinusChars = "-Ww";
-        private static readonly Regex LongitudeDegreeRegex = new(@"^(-?[1]?[0-7]?[0-9](?:\.\d{1,6})?|180(?:\.0{1,6})?)$", RegexOptions.Compiled);
+        //private static readonly Regex LongitudeDegreeRegex = new(@"^(-?[1]?[0-7]?[0-9](?:\.\d{1,6})?|180(?:\.0{1,6})?)$", RegexOptions.Compiled);
+        private static readonly Regex LongitudeDegreeRegex = new(@"^[\+-]?((1[0-7]\d|[1-9]?\d)(\.\d{1,})?|180)\D*[EWew]?$", RegexOptions.Compiled);
         
         private static readonly Regex LongitudeRegex = new(
             @"((?<s1>(\+|\-|E|e|W|w))?(?<deg>[0-9]{0,2}\d|180)(°|˚|º|\^|~|\*|\s|\-|_)*((?<min>[0-5]?\d|\d)?)('|′|\s|\-|_)*(?<sec>(([0-5]?\d|\d)([.]\d*)?))?(""|¨|˝|\s|\-|_)*(?<s2>(\+|\-|E|e|W|w))?)[\s]*$", 
@@ -25,14 +26,14 @@ namespace Asv.Common
             return IsValid(value) == false ? RS.GeoPointLongitude_GetErrorMessage : null;
         }
 
-        public static bool TryParse(string? value, out double latitude)
+        public static bool TryParse(string? value, out double longitude)
         {
-            latitude = Double.NaN;
+            longitude = Double.NaN;
             if (string.IsNullOrWhiteSpace(value)) return false;
             value = value.Replace(',', '.');
             if (LongitudeDegreeRegex.IsMatch(value))
             {
-                if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out latitude))
+                if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out longitude))
                 {
                     return true;
                 }
@@ -41,9 +42,9 @@ namespace Asv.Common
             var match = LongitudeRegex.Match(value);
             if (match.Success == false)
             {
-                if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out latitude) == false)
+                if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out longitude) == false)
                     return false;
-                return latitude is >= Min and <= Max;
+                return longitude is >= Min and <= Max;
             }
 
             var degGroup = match.Groups["deg"];
@@ -95,8 +96,8 @@ namespace Asv.Common
             {
                 return false;
             }
-            latitude = (s1Group.Success ? sign1 : sign2) * (deg + (double)min / 60 + sec / 3600);
-            return latitude is >= Min and <= Max;
+            longitude = (s1Group.Success ? sign1 : sign2) * (deg + (double)min / 60 + sec / 3600);
+            return longitude is >= Min and <= Max;
         }
         public static string PrintDms(double longitude)
         {


### PR DESCRIPTION
Updated the regex in the `GeoPointLongitude` class for more accurate longitude data extraction. Specifically, enhanced string longitude parsing function to handle degrees, minutes, and seconds, allowing it to better handle various longitude formats. Also rectified the unintentional naming from latitude to longitude for better code clarity.

Asana: https://app.asana.com/0/1203851531040615/1205904416342371/f