### PR TITLE
fix(asv-io-test): replace Thread.Sleep with FakeTimeProvider in tests

### DIFF
--- a/src/Asv.IO.Test/Asv.IO.Test.csproj
+++ b/src/Asv.IO.Test/Asv.IO.Test.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DeepEqual" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/Asv.IO.Test/Streams/TelnetStreamTest.cs
+++ b/src/Asv.IO.Test/Streams/TelnetStreamTest.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Asv.IO.Test.Streams
+namespace Asv.IO.Test
 {
     public class TelnetStreamTest
     {


### PR DESCRIPTION
Update tests for TCP, UDP, and Serial ports to use FakeTimeProvider instead of Thread.Sleep, enabling virtual time control for faster and more predictable test execution. This change improves test performance and reliability by eliminating real-time delays

Asana: https://app.asana.com/0/1203851531040615/1208676147074850/f