### PR TITLE
fix: add proper cancellation to ProtocolConnection

### DIFF
--- a/src/Asv.IO/Protocol/Connection/Endpoint/ProtocolEndpoint.cs
+++ b/src/Asv.IO/Protocol/Connection/Endpoint/ProtocolEndpoint.cs
@@ -195,9 +195,21 @@ public abstract class ProtocolEndpoint: ProtocolConnection, IProtocolEndpoint
   
     public override ValueTask Send(IProtocolMessage message, CancellationToken cancel = default)
     {
-        if (IsDisposed) return ValueTask.CompletedTask;
-        if (_lastError.CurrentValue != null) return ValueTask.CompletedTask;
-        cancel.ThrowIfCancellationRequested();
+        if (cancel.IsCancellationRequested)
+        {
+            return ValueTask.FromException(new OperationCanceledException());
+        }
+        
+        if (IsDisposed)
+        {
+            return ValueTask.CompletedTask;
+        }
+        
+        if (_lastError.CurrentValue != null)
+        {
+            return ValueTask.CompletedTask;
+        }
+        
         return _txChannel.Writer.WriteAsync(message, cancel);
     }
 

--- a/src/Asv.IO/Protocol/Connection/Port/ProtocolPort.cs
+++ b/src/Asv.IO/Protocol/Connection/Port/ProtocolPort.cs
@@ -202,7 +202,11 @@ public abstract class ProtocolPort<TConfig> : ProtocolConnection, IProtocolPort
             if (_startStopCancel != null)
             {
                 var cancel = _startStopCancel;
-                if (cancel.IsCancellationRequested == false) cancel.Cancel(false);
+                if (cancel.IsCancellationRequested == false)
+                {
+                    cancel.Cancel(false);
+                }
+                
                 cancel.Dispose();
                 _startStopCancel = null;
             }
@@ -243,7 +247,11 @@ public abstract class ProtocolPort<TConfig> : ProtocolConnection, IProtocolPort
     protected abstract void InternalSafeEnable(CancellationToken token);
     public override async ValueTask Send(IProtocolMessage message, CancellationToken cancel = default)
     {
-        if (IsDisposed) return;
+        if (IsDisposed)
+        {
+            return;
+        }
+        
         cancel.ThrowIfCancellationRequested();
         var newMessage = await InternalFilterTxMessage(message);
         if (newMessage == null) return;

--- a/src/Asv.IO/Protocol/Connection/ProtocolConnection.cs
+++ b/src/Asv.IO/Protocol/Connection/ProtocolConnection.cs
@@ -38,8 +38,6 @@ public abstract class ProtocolConnection : AsyncDisposableWithCancel, IProtocolC
         {
             feature.Register(this);
         }
-        
-        
     }
 
     public string Id { get; }
@@ -136,6 +134,4 @@ public abstract class ProtocolConnection : AsyncDisposableWithCancel, IProtocolC
     }
 
     #endregion
-
-    
 }

--- a/src/Asv.IO/Protocol/Connection/Router/ProtocolRouter.cs
+++ b/src/Asv.IO/Protocol/Connection/Router/ProtocolRouter.cs
@@ -25,7 +25,11 @@ public sealed class ProtocolRouter:ProtocolConnection, IProtocolRouter
 
     public override async ValueTask Send(IProtocolMessage message, CancellationToken cancel = default)
     {
-        if (IsDisposed) return;
+        if (IsDisposed)
+        {
+            return;
+        }
+        
         cancel.ThrowIfCancellationRequested();
         var newMessage = await InternalFilterTxMessage(message);
         if (newMessage == null) return;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,10 @@
 <Project>
   <PropertyGroup>
-    <ProductVersion>3.0.1</ProductVersion>
+    <ProductVersion>3.0.0-dev.13</ProductVersion>
+    <ProductPrevVersion>3.0.0</ProductPrevVersion>
     <R3Version>1.2.9</R3Version>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
+    <ApiCompatVersion>8.0.200</ApiCompatVersion>
     <ZLoggerVersion>2.5.5</ZLoggerVersion>
     <DeepEqualVersion>4.2.1</DeepEqualVersion>
     <AutoFixtureVersion>4.18.1</AutoFixtureVersion>


### PR DESCRIPTION
cancellation token removed from sync methods, placed in a higher hierarchy methods 
Asana: https://app.asana.com/0/1203851531040615/1208996225958251/f