### PR TITLE
Fixed BUG: In case of ProtocolParserCrcException, internal parser would be called

### DIFF
--- a/src/Asv.IO/Protocol/Parser/ProtocolParser.cs
+++ b/src/Asv.IO/Protocol/Parser/ProtocolParser.cs
@@ -58,6 +58,7 @@ public abstract class ProtocolParser<TMessage,TMessageId> : AsyncDisposableOnce,
         {
             InternalOnError(ex);
             StatisticHandler.IncrementParserBadCrcError();
+            return;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Fixed BUG: In case of ProtocolParserCrcException, internal parser would be called